### PR TITLE
Fix Wrapper hang on Discord rate limit.

### DIFF
--- a/FactorioWebInterface/Hubs/FactorioProcessHub.cs
+++ b/FactorioWebInterface/Hubs/FactorioProcessHub.cs
@@ -1,5 +1,4 @@
-﻿using FactorioWebInterface.Models;
-using FactorioWebInterface.Services;
+﻿using FactorioWebInterface.Services;
 using FactorioWebInterface.Utils;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.AspNetCore.Authorization;
@@ -48,7 +47,7 @@ namespace FactorioWebInterface.Hubs
                 _factorioServerManger.FactorioDataReceived(serverId, data, dateTime);
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public Task SendWrapperDataWithDateTime(string data, DateTime dateTime)
@@ -58,17 +57,17 @@ namespace FactorioWebInterface.Hubs
                 _factorioServerManger.FactorioWrapperDataReceived(serverId, data, dateTime);
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
 
         public Task StatusChangedWithDateTime(FactorioServerStatus newStatus, FactorioServerStatus oldStatus, DateTime dateTime)
         {
             if (Context.TryGetData(out string? serverId) && serverId != null)
             {
-                return _factorioServerManger.StatusChanged(serverId, newStatus, oldStatus, dateTime);
+                _ = _factorioServerManger.StatusChanged(serverId, newStatus, oldStatus, dateTime);
             }
 
-            return Task.FromResult(0);
+            return Task.CompletedTask;
         }
     }
 }

--- a/FactorioWrapperInterface/FactorioServerStatus.cs
+++ b/FactorioWrapperInterface/FactorioServerStatus.cs
@@ -47,7 +47,6 @@
         {
             switch (status)
             {
-                case FactorioServerStatus.Unknown:
                 case FactorioServerStatus.WrapperStarted:
                 case FactorioServerStatus.Starting:
                 case FactorioServerStatus.Running:


### PR DESCRIPTION
Discord.Net appears to have a bug where it fails to send a request when hitting rate limits and wait to timeout. Turns out when changing status the Wrapper was waiting for the request to be sent to Discord before allowing more messages to be sent. I have stopped the Wrapper from waiting on Discord now. I have also stopped waiting on Discord request to finish in the server manager.